### PR TITLE
Bootstrap grid index

### DIFF
--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -58,8 +58,7 @@
       </div>
     </div>
   </div>
-  <div id="jobs" class="jobs container my-3">
-    <div class="d-flex justify-content-between align-items-center my-4">
+  <div class="d-flex justify-content-between align-items-center my-4">
       <h3>Your jobs</h3>
       <div>
         <!-- Button trigger modal -->
@@ -74,6 +73,5 @@
         <%= render 'jobs/job_list', job: job %>
       </div>
     <% end %>
-  </div>
  </div>
 </div>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -1,7 +1,6 @@
-<div class="container my-5">
-  <div class="d-flex justify-content-between">
-    <h2>Welcome back, <%= current_user.first_name.capitalize %>!</h2>
-  </div>
+<div class="row justify-content-center mx-3">
+ <div class="col-sm-12 col-md-8 col-lg-8">
+  <h2>Welcome back, <%= current_user.first_name.capitalize %>!</h2>
   <div id="job-stats" class="my-3">
     <div class="d-flex flex-column job-stats">
       <h3>Your job stats</h3>
@@ -76,4 +75,5 @@
       </div>
     <% end %>
   </div>
+ </div>
 </div>


### PR DESCRIPTION
wrapped index page in a bootstrap grid instead of a container to make it more responsive and got rid of the extra padding on the jobs list.