### PR TITLE
override bootstrap focus styling

### DIFF
--- a/app/assets/stylesheets/components/_home.scss
+++ b/app/assets/stylesheets/components/_home.scss
@@ -37,3 +37,9 @@
   color: black;
   border: none;
 }
+
+.btn:focus {
+  background-color: #68E1FD;
+  color: black;
+  border: none;
+}


### PR DESCRIPTION
no longer turns blue