### PR TITLE
corrected meta description

### DIFF
--- a/config/meta.yml
+++ b/config/meta.yml
@@ -1,4 +1,4 @@
 meta_product_name: "JobJob"
 meta_title: "JobJob - Keep track of all your job applications in one place"
-meta_description: "JobJob is a tool that helps you keep track of all your job applications. You can add tasks, notes and documents to each job and track the status of your application."
+meta_description: "JobJob is a tool that helps you keep track of all your job applications. Add tasks, notes and documents to each job and change the application status as you progress in your job search."
 meta_image: "cover.jpg"


### PR DESCRIPTION
meta_product_name: "JobJob"
meta_title: "JobJob - Keep track of all your job applications in one place"
meta_description: "JobJob is a tool that helps you keep track of all your job applications. Add tasks, notes and documents to each job and change the application status as you progress in your job search."